### PR TITLE
Amazon Linux 2 compatibility

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,6 +19,12 @@ class yum_cron::params {
           $debug_level      = '0'
           $randomwait       = '60'
         }
+        
+        '2': {
+          $config_path      = '/etc/yum/yum-cron.conf'
+          $debug_level      = '-2'
+          $randomwait       = '360'
+        }
         default: {
           fail("Unsupported operatingsystemmajrelease: ${::operatingsystemmajrelease}, module ${module_name} only support 6 and 7")
         }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@ class yum_cron::params {
       $service_hasrestart = true
 
       case $::operatingsystemmajrelease {
-        '7': {
+        '7','2': {
           $config_path      = '/etc/yum/yum-cron.conf'
           $debug_level      = '-2'
           $randomwait       = '360'
@@ -20,11 +20,6 @@ class yum_cron::params {
           $randomwait       = '60'
         }
         
-        '2': {
-          $config_path      = '/etc/yum/yum-cron.conf'
-          $debug_level      = '-2'
-          $randomwait       = '360'
-        }
         default: {
           fail("Unsupported operatingsystemmajrelease: ${::operatingsystemmajrelease}, module ${module_name} only support 6 and 7")
         }


### PR DESCRIPTION
Added operatingsystemmajrelease: 2 to support Amazon Linux 2 yum-cron module.